### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Remove gitignore files from github-pages folder for deploy
         run: |
-          rm output/github-pages/.gitignore
-          rm output/github-pages/**/.gitignore
+          rm -f output/github-pages/.gitignore
+          rm -f output/github-pages/**/.gitignore
 
       - name: Deploy presentation to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.0.0


### PR DESCRIPTION
rm: cannot remove 'output/github-pages/**/.gitignore': No such file or
directory